### PR TITLE
[HGNN-7926] loginWithLimitedTracking 사용법 변경

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="4.1.2-hogangnono"></a>
+
+# [4.1.2-hogangnono] (2024-07-16)
+
+## Refactor
+* enable to call initWithPermissions without nonce (set by uuid in sdk)
+
 <a name="4.1.1"></a>
 
 # [4.1.1](https://github.com/MaximBelov/cordova-plugin-fbsdk/releases/tag/v4.1.1) (2024-06-28)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-fbsdk",
-  "version": "4.1.1",
+  "version": "4.1.2-hogangnono",
   "description": "Cordova Facebook SDK Plugin",
   "cordova": {
     "id": "cordova-plugin-fbsdk",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-fbsdk"
-        version="4.1.1">
+        version="4.1.2-hogangnono">
 
     <name>Facebook Connect</name>
 

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -358,14 +358,6 @@
 }
 
 - (void)loginWithLimitedTracking:(CDVInvokedUrlCommand *)command {
-    if ([command.arguments count] == 1) {
-        NSString *nonceErrorMessage = @"No nonce specified";
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                         messageAsString:nonceErrorMessage];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        return;
-    }
-
     NSArray *permissions = [command argumentAtIndex:0];
     NSArray *permissionsArray = @[];
     NSString *nonce = [command argumentAtIndex:1];
@@ -396,7 +388,14 @@
         self.loginManager = [FBSDKLoginManager new];
     }
     self.loginTracking = FBSDKLoginTrackingLimited;
-    FBSDKLoginConfiguration *configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:permissionsArray tracking:FBSDKLoginTrackingLimited nonce:nonce];
+
+    FBSDKLoginConfiguration *configuration;
+    if ((![nonce isEqual:[NSNull null]]) && ([nonce length] != 0)) {
+        configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:permissionsArray tracking:FBSDKLoginTrackingLimited nonce:nonce];
+    } else {
+        configuration = [[FBSDKLoginConfiguration alloc] initWithPermissions:permissionsArray tracking:FBSDKLoginTrackingLimited];
+    }
+
     [self.loginManager logInFromViewController:[self topMostController] configuration:configuration completion:loginHandler];
 }
 


### PR DESCRIPTION
### [JIRA]
https://zigbang.atlassian.net/browse/HGNN-7926

### [WORK]
- [fix: enable to call initWithPermissions without nonce](https://github.com/hogangnono/cordova-plugin-fbsdk/commit/728768ee69da9c04c3755a2d758cca3570f33127)
- [nonce 없이 호출하면 sdk 내부에서 uuid로 셋팅](https://github.com/facebook/facebook-ios-sdk/blob/707447b93b3566c10d3f91343c4cc673ec6e5f1e/FBSDKLoginKit/FBSDKLoginKit/LoginConfiguration.swift#L128)